### PR TITLE
[GPU] Fix GenerateDynamics and DynamicMiner

### DIFF
--- a/src/miner-gpu.h
+++ b/src/miner-gpu.h
@@ -4,26 +4,27 @@
 #define DYNAMIC_ARGON2_GPU
 
 #ifdef ENABLE_GPU
-#define HAVE_CUDA 1
-#define ARGON2_GPU_CUDA cuda
-#define ARGON2_GPU_OPENCL opencl
-
-#define ARGON2_GPU ARGON2_GPU_CUDA
+#define HAVE_CUDA
 
 #include <cstddef>
+
+#include "argon2-gpu/common.h"
+#ifndef HAVE_CUDA
 #include "argon2-cuda/cuda-exception.h"
 #include "argon2-cuda/processing-unit.h"
-#include "argon2-gpu/common.h"
+#else
+#include "argon2-opencl/opencl.h"
 #include "argon2-opencl/processing-unit.h"
+#endif
 
 using Argon2GPUParams = argon2gpu::Argon2Params;
 
-#if ARGON2_GPU == ARGON2_GPU_CUDA
+#ifndef HAVE_CUDA
 using Argon2GPU = argon2gpu::cuda::ProcessingUnit;
 using Argon2GPUDevice = argon2gpu::cuda::Device;
 using Argon2GPUContext = argon2gpu::cuda::GlobalContext;
 using Argon2GPUProgramContext = argon2gpu::cuda::ProgramContext;
-#elif ARGON2_GPU == ARGON2_GPU_OPENCL
+#else
 using Argon2GPU = argon2gpu::opencl::ProcessingUnit;
 using Argon2GPUDevice = argon2gpu::opencl::Device;
 using Argon2GPUContext = argon2gpu::opencl::GlobalContext;

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -306,8 +306,12 @@ UniValue setgenerate(const JSONRPCRequest& request)
             "2. genproclimit     (numeric, optional) Set the processor limit for when generation is on. Can be -1 for unlimited.\n"
             "3. genproclimit-gpu (numeric, optional) Set the GPU thread limit for when generation is on. Can be -1 for unlimited.\n"
             "\nExamples:\n"
-            "\nSet the generation on with a limit of one processor\n"
+            "\nSet the generation on with a limit of one CPU processor\n"
             + HelpExampleCli("setgenerate", "true 1") +
+#if ENABLE_GPU   
+            "\nSet the generation on with a limit of one GPU\n"
+            + HelpExampleCli("setgenerate", "true 0 1") +
+#endif
             "\nCheck the setting\n"
             + HelpExampleCli("getgenerate", "") +
             "\nTurn off generation\n"
@@ -328,7 +332,7 @@ UniValue setgenerate(const JSONRPCRequest& request)
         nGenProcLimit = request.params[1].get_int();
 
     int nGenProcLimitGPU = GetArg("-genproclimit-gpu", DEFAULT_GENERATE_THREADS_GPU);
-    if (request.params.size() > 1)
+    if (request.params.size() > 2)
         nGenProcLimitGPU = request.params[2].get_int();
 
     if (nGenProcLimit == 0 && nGenProcLimitGPU == 0)
@@ -337,6 +341,7 @@ UniValue setgenerate(const JSONRPCRequest& request)
     GetArg("-gen", "") = (fGenerate ? "1" : "0");
     GetArg("-genproclimit", "") = itostr(nGenProcLimit);
     GetArg("-genproclimit-gpu", "") = itostr(nGenProcLimitGPU);
+    LogPrintf("setgenerate cpu = %u, gpu = %u \n", nGenProcLimit, nGenProcLimitGPU);
     GenerateDynamics(nGenProcLimit, nGenProcLimitGPU, Params(), *g_connman);
 
     return NullUniValue;


### PR DESCRIPTION
- fix create CPU threads so it doesn't lookup a GPU device (device ordinal segfault)
- change miner-gpu header to build with OpenCL
-- still need to define HAVE_CUDA in configure if CUDA installed